### PR TITLE
Use the errno crate rather than reading errno manually.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ std = []
 
 [dependencies]
 libc = { version = "0.2", default-features = false }
+errno = { version = "0.2.8", default-features = false }
 bitflags = "1.2"
 
 [dev-dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,17 +1,8 @@
 use crate::slicevec::SliceVec;
 
-#[cfg(any(target_os = "linux", target_os = "dragonfly"))]
-pub use libc::__errno_location as errno_ptr;
-
-#[cfg(any(target_os = "freebsd", target_os = "macos"))]
-pub use libc::__error as errno_ptr;
-
-#[cfg(any(target_os = "android", target_os = "netbsd", target_os = "openbsd"))]
-pub use libc::__errno as errno_ptr;
-
 #[inline]
 pub fn errno_get() -> i32 {
-    unsafe { *errno_ptr() }
+    errno::errno().0
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The errno crate supports more platforms. In my specific case, I need
wasm32-wasi support.

The errno crate also supports no_std when used with no-default-features,
so realpath-ext can continue to support no_std.