### PR TITLE
Update to errno 0.3.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ std = []
 
 [dependencies]
 libc = { version = "0.2", default-features = false }
-errno = { version = "0.2.8", default-features = false }
+errno = { version = "0.3.0", default-features = false }
 bitflags = "1.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This fixes compilation on WASI on Rust stable.